### PR TITLE
add filter to compatible with mysql 8.0

### DIFF
--- a/addition_to_sys.sql
+++ b/addition_to_sys.sql
@@ -63,7 +63,7 @@ BEGIN
 performance_schema.replication_group_members WHERE MEMBER_STATE != 'ONLINE') >=
 ((SELECT COUNT(*) FROM performance_schema.replication_group_members)/2) = 0),
 'YES', 'NO' ) FROM performance_schema.replication_group_members JOIN
-performance_schema.replication_group_member_stats USING(member_id));
+performance_schema.replication_group_member_stats member_stats USING(member_id) where member_stats.MEMBER_ID = @@server_uuid) ;
 END$$
 
 CREATE VIEW gr_member_routing_candidate_status AS SELECT
@@ -71,6 +71,8 @@ sys.gr_member_in_primary_partition() as viable_candidate,
 IF( (SELECT (SELECT GROUP_CONCAT(variable_value) FROM
 performance_schema.global_variables WHERE variable_name IN ('read_only',
 'super_read_only')) != 'OFF,OFF'), 'YES', 'NO') as read_only,
-sys.gr_applier_queue_length() as transactions_behind, Count_Transactions_in_queue as 'transactions_to_cert' from performance_schema.replication_group_member_stats;$$
+sys.gr_applier_queue_length() as transactions_behind, Count_Transactions_in_queue as 'transactions_to_cert' from performance_schema.replication_group_member_stats
+where member_id = (select gv.VARIABLE_VALUE 
+ from `performance_schema`.global_variables gv where gv.VARIABLE_NAME='server_uuid');$$
 
 DELIMITER ;


### PR DESCRIPTION
on mysql  8.0,  performance_schema.replication_group_member_stats contains all mysql node in mgr cluster, while in mysq. 5.7, this table only contains the  node you have just connected.